### PR TITLE
중앙 정렬 수정 및 일정 상세 모달에서 일정 추가 기능 추가

### DIFF
--- a/src/components/AddScheduleModal.tsx
+++ b/src/components/AddScheduleModal.tsx
@@ -4,6 +4,7 @@ import { useScheduleStore } from '@/store/ScheduleStore';
 
 type Props = {
   close: () => void;
+  prevClose: () => void;
 } & React.ComponentPropsWithoutRef<'div'>;
 
 export type FormDataProps = {
@@ -15,7 +16,7 @@ export type FormDataProps = {
   isAllDay: boolean;
 };
 
-const AddScheduleModal = ({ close }: Props) => {
+const AddScheduleModal = ({ close, prevClose }: Props) => {
   const addSchedule = useScheduleStore((state) => state.addSchedule);
   const [formData, setFormData] = useState<FormDataProps>({
     title: '',
@@ -48,6 +49,7 @@ const AddScheduleModal = ({ close }: Props) => {
       isAllDay: formData.isAllDay,
     });
 
+    prevClose();
     close();
   };
 

--- a/src/components/CalendarWrapper.tsx
+++ b/src/components/CalendarWrapper.tsx
@@ -67,22 +67,22 @@ const Buttons = () => {
   };
 
   return (
-    <div className="flex fixed top-11 ml-4 gap-4">
-      <strong className="text-lg w-20">
+    <div className="flex fixed mt-1 top-11 ml-4 gap-4">
+      <strong className="text-lg flex items-center w-20">
         {currentDate.getFullYear()}. {calculateMonth(currentDate.getMonth() + 1)}
       </strong>
       <div className="flex gap-1">
         <ScheduleBtn
-          className="border rounded-md w-8 flex items-center justify-center text-lg text-sky-400 border-sky-400"
+          className="border rounded-md w-8 h-8 flex relative items-center justify-center text-lg  text-sky-400 border-sky-400"
           onClick={() => setCurrentDate(subMonths(currentDate, 1))}
         >
-          {'<'}
+          <p className="pb-[2px]">{'<'}</p>
         </ScheduleBtn>
         <ScheduleBtn
-          className="border rounded-md w-8 flex items-center text-lg justify-center text-sky-400 border-sky-400"
+          className="border rounded-md w-8 h-8 flex relative items-center text-lg justify-center text-sky-400 border-sky-400"
           onClick={() => setCurrentDate(subMonths(currentDate, -1))}
         >
-          {'>'}
+          <p className="pb-[2px]">{'>'}</p>
         </ScheduleBtn>
         <ScheduleBtn
           className="border rounded-md w-8 flex items-center justify-center text-xs text-sky-400 border-sky-400"
@@ -92,12 +92,16 @@ const Buttons = () => {
         </ScheduleBtn>
         <ScheduleBtn
           onClick={openModal}
-          className="border rounded-md w-8 flex items-center justify-center text-lg text-sky-400 border-sky-400"
+          className="border rounded-md w-8 h-8 pb-[2px] flex items-center justify-center text-lg text-sky-400 border-sky-400"
         >
           +
         </ScheduleBtn>
       </div>
-      {isShowModal && <AddScheduleModal close={closeModal}>일정 추가</AddScheduleModal>}
+      {isShowModal && (
+        <AddScheduleModal close={closeModal} prevClose={closeModal}>
+          일정 추가
+        </AddScheduleModal>
+      )}
     </div>
   );
 };
@@ -127,6 +131,10 @@ const Days = () => {
   const [schedulesByDay, setSchedulesByDay] = useState<Record<string, Schedule[]>>({});
   const { weekCalendarList, currentDate } = useCalendarContext();
   const { isShowModal, dateObj, modalSchedule, openModal, closeModal } = useScheduleModal();
+
+  useEffect(() => {
+    console.log('isShowModal', isShowModal);
+  }, [isShowModal]);
 
   const schedules = useScheduleStore((state) => state.schedules);
   const getSchedulesByDate = useScheduleStore((state) => state.getSchedulesByDate);

--- a/src/components/ScheduleModal.tsx
+++ b/src/components/ScheduleModal.tsx
@@ -7,6 +7,8 @@ import { useScheduleStore } from '@/store/ScheduleStore';
 import DeleteSvg from './svg/DeleteSvg';
 import ModifySvg from './svg/ModifySvg';
 import UpdateScheduleModal from './UpdateScheduleModal';
+import AddScheduleModal from './AddScheduleModal';
+
 import { useState } from 'react';
 
 type Props = ComponentPropsWithoutRef<typeof Modal> & {
@@ -16,10 +18,16 @@ type Props = ComponentPropsWithoutRef<typeof Modal> & {
 
 const ScheduleModal = ({ close, schedule }: Props) => {
   const deleteSchedule = useScheduleStore((state) => state.deleteSchedule);
+  const [isShowAddModal, setIsShowAddModal] = useState(false);
   const [isShowModal, setIsShowModal] = useState(false);
 
-  const openModal = () => setIsShowModal(true);
-  const closeModal = () => setIsShowModal(false);
+  const openUpdateModal = () => setIsShowModal(true);
+  const closeUpdateModal = () => setIsShowModal(false);
+
+  const openAddModal = () => {
+    setIsShowAddModal(true);
+  };
+  const closeAddModal = () => setIsShowAddModal(false);
 
   const handleDelete = () => {
     if (schedule) {
@@ -37,14 +45,10 @@ const ScheduleModal = ({ close, schedule }: Props) => {
               <h3 className="text-lg flex mt-1 font-bold">{schedule.title}</h3>
               {schedule && (
                 <div className="flex gap-1">
-                  <button 
-                  title='일정 수정'
-                  onClick={openModal}>
+                  <button title="일정 수정" onClick={openUpdateModal}>
                     <ModifySvg />
                   </button>
-                  <button 
-                  title='일정 삭제'
-                  onClick={handleDelete}>
+                  <button title="일정 삭제" onClick={handleDelete}>
                     <DeleteSvg />
                   </button>
                 </div>
@@ -58,10 +62,19 @@ const ScheduleModal = ({ close, schedule }: Props) => {
             )}
           </div>
         ) : (
-          <p className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">일정이 없습니다.</p>
+          <p className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col gap-2">
+            일정이 없습니다.
+            <button
+              onClick={openAddModal}
+              className="text-white font-bold text-sm bg-sky-500 rounded-xl hover:opacity-55"
+            >
+              일정 추가하기
+            </button>
+          </p>
         )}
       </div>
-      {isShowModal && <UpdateScheduleModal schedule={schedule} close={closeModal} prevClose={close} />}
+      {isShowAddModal && <AddScheduleModal close={closeAddModal} prevClose={close} />}
+      {isShowModal && <UpdateScheduleModal schedule={schedule} close={closeUpdateModal} prevClose={close} />}
     </Modal>
   );
 };

--- a/src/components/UpdateScheduleModal.tsx
+++ b/src/components/UpdateScheduleModal.tsx
@@ -3,8 +3,6 @@ import Modal from './Modal';
 import { useScheduleStore } from '@/store/ScheduleStore';
 import { Schedule } from '@/libs/internalTypes';
 
-import { useRouter } from 'next/navigation';
-
 type Props = {
   close: () => void;
   schedule: Schedule | null;
@@ -22,7 +20,6 @@ export type FormDataProps = {
 
 const UpdateScheduleModal = ({ schedule, close, prevClose }: Props) => {
   const updateSchedule = useScheduleStore((state) => state.updateSchedule);
-  const router = useRouter();
 
   const [formData, setFormData] = useState<FormDataProps>({
     title: schedule?.title || '',


### PR DESCRIPTION
## 📝작업 내용
- AddModal을 띄워주는 버튼 생성
- close를 props로 받아, 일정을 등록할 경우 하위 레이어의 모달 종료
