### PR TITLE
V 1.7.0

### DIFF
--- a/src/components/Calendar/Buttons/ButtonsWrapper.tsx
+++ b/src/components/Calendar/Buttons/ButtonsWrapper.tsx
@@ -69,7 +69,7 @@ const TodayButton = () => {
 
   return (
     <ScheduleBtn
-      className={clsx('border rounded-md w-8 flex items-center justify-center text-xs', 'text-sky-400 border-sky-400', {
+      className={clsx('border rounded-md w-8 flex items-center', 'justify-center text-xs text-sky-400 border-sky-400', {
         'border-slate-300 text-slate-300': theme === 'DARK',
       })}
       onClick={() => setCurrentDate(new Date())}

--- a/src/components/Calendar/CalendarWrapper.tsx
+++ b/src/components/Calendar/CalendarWrapper.tsx
@@ -121,7 +121,7 @@ const Days = () => {
   const { theme } = useThemeContext();
   const { isShowModal, dateObj, modalSchedule, openModal, closeModal } = useScheduleModal();
   const { schedulesByDay } = useCalendarGrid();
-  const today = useClientDate(); // 커스텀 훅으로 hydration 처리
+  const today = useClientDate({ refreshInterval: 3000 }); // 커스텀 훅으로 hydration 처리
 
   if (!today) {
     return <InitialCalendar weekCalendarList={weekCalendarList} />;

--- a/src/components/layout/Header/HeaderControlBtn.tsx
+++ b/src/components/layout/Header/HeaderControlBtn.tsx
@@ -19,9 +19,8 @@ const HeaderControlButton = ({ componentType, ...rest }: Props) => {
     <div className={clsx('relative h-10 w-10')}>
       <button
         className={clsx(
-          'inline-flex h-full w-full items-center justify-center overflow-hidden rounded-md',
-          'text-content-neutral-primary',
-          'hover:bg-surface-neutral-strong bg-transparent',
+          'inline-flex h-full w-full items-center justify-center',
+          'overflow-hidden rounded-md bg-transparent',
         )}
         {...rest}
       >

--- a/src/configs/tailwind.constant.ts
+++ b/src/configs/tailwind.constant.ts
@@ -6,7 +6,7 @@ export const HOME_MIN_HEIGHT = `calc(100vh - ${HEADER_HEIGHT})`;
 export const CALENDAR_MIN_HEIGHT = `calc(100vh - ${CALENDAR_HEIGHT})`;
 
 export const DATE_MONTH_FIXER = 1;
-export const CALENDER_LENGTH = 35;
+export const CALENDAR_LENGTH = 42;
 export const DEFAULT_TRASH_VALUE = 0;
 export const DAY_OF_WEEK = 7;
 export const DAY_LIST = ['일', '월', '화', '수', '목', '금', '토'];

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { getDaysInMonth, subMonths } from 'date-fns';
-import { CALENDER_LENGTH, DAY_OF_WEEK } from '../configs/tailwind.constant';
+import { CALENDAR_LENGTH, DAY_OF_WEEK } from '../configs/tailwind.constant';
 
 const useCalendar = () => {
   const [currentDate, setCurrentDate] = React.useState(new Date());
@@ -29,7 +29,7 @@ const useCalendar = () => {
   }));
 
   const nextDayList = Array.from({
-    length: CALENDER_LENGTH - currentDayList.length - prevDayList.length,
+    length: CALENDAR_LENGTH - currentDayList.length - prevDayList.length,
   }).map((_, index) => ({
     year: currentDate.getFullYear(),
     day: index + 1,

--- a/src/hooks/useClientDate.ts
+++ b/src/hooks/useClientDate.ts
@@ -1,11 +1,21 @@
 import { useState, useEffect } from 'react';
 
-const useClientDate = () => {
-  const [today, setToday] = useState<Date | null>(null);
+type Props = {
+  refreshInterval?: number;
+};
+
+const useClientDate = ({ refreshInterval }: Props) => {
+  const [today, setToday] = useState(() => new Date());
 
   useEffect(() => {
-    setToday(new Date());
-  }, []);
+    if (!refreshInterval) return;
+
+    const interval = setInterval(() => {
+      setToday(new Date());
+    }, refreshInterval);
+
+    return () => clearInterval(interval);
+  }, [refreshInterval]);
 
   return today;
 };


### PR DESCRIPTION
## 📝작업 내용

### useClientDate에 interval 추가
- 기존의 hooks은 컴포넌트 초기 렌더링시에만 시간을 동기화했음.
- 이는 side-effect를 야기할것으로 예상되어 interval을 추가하여 주기적으로 시간을 동기화하도록 함

### 매직 넘버 수정
- CALENDAR_LENGTH 를 35 -> 42로 변경함으로써 달력에 통일성 부여

### 스크린샷 (선택)

<img width="1440" alt="스크린샷 2025-01-21 오전 12 19 40" src="https://github.com/user-attachments/assets/4f71f45a-1379-4260-b8cb-06153bafc344" />
